### PR TITLE
adjusted to config api changes, fixes #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,14 @@
                     "type": "string",
                     "default": "",
                     "description": "Configuration file for the code style check"
+                },
+                "haxecheckstyle.sourceFolders": {
+                    "type": "array",
+                    "default": [
+                        "src",
+                        "Source"
+                    ],
+                    "description": "Source folders for code style check"
                 }
             }
         }

--- a/src/VSCodeReporter.hx
+++ b/src/VSCodeReporter.hx
@@ -8,7 +8,7 @@ class VSCodeReporter extends BaseReporter {
 
     override public function addMessage(m:CheckMessage) {
         var range = new Range(m.line - 1, m.startColumn, m.line - 1, m.endColumn);
-        var diag = new Diagnostic(range, m.message, Information);
+        var diag = new Diagnostic(range, m.moduleName + " - " + m.message, Information);
         diag.source = "checkstyle";
         diagnostics.push(diag);
     }


### PR DESCRIPTION
- adjusted to config api changes
- include check name within diagnostic message
- new user setting `haxecheckstyle.sourceFolders` to
  - support excludes
  - restrict files to run checkstyle on